### PR TITLE
Fix 'buttons' outlet misfires

### DIFF
--- a/nocturn.c
+++ b/nocturn.c
@@ -369,7 +369,7 @@ void *nocturn_write(t_nocturn *x)                                       /// WRIT
 void *nocturn_read(t_nocturn *x)                                        /// READING-THREAD
 {
     unsigned char tmp[8];
-    int ret;
+    int actual_length;
     int error;
     int i;
     int oi;
@@ -378,7 +378,7 @@ void *nocturn_read(t_nocturn *x)                                        /// READ
     {
         memset(tmp, 0, sizeof(tmp));
         
-        error = libusb_interrupt_transfer(x->dev_handle, 0x81, tmp, sizeof(tmp), &ret, 0);
+        error = libusb_interrupt_transfer(x->dev_handle, 0x81, tmp, sizeof(tmp), &actual_length, 0);
         
         if (x->readthread_cancel) // test if we're being asked to die
             break;
@@ -412,7 +412,7 @@ void *nocturn_read(t_nocturn *x)                                        /// READ
             if (x->dataIn[i][0] == 0)// find free slot
             {
                //put data in and break
-                for (oi=0;oi<8;oi++)
+                for (oi=0; oi<actual_length; oi++)
                 {
                     x->dataIn[i][oi] = tmp[oi];
                 }


### PR DESCRIPTION
Was getting false triggering of the button outlet, when moving just the encoders or the fader. This patch fixes that, by having the nocturn_read method only copy the actual_length (from libusb_interrupt_transfer) of bytes transferred. (Currently it's always copying in the full 8 bytes that that it reads from the Nocturn, but sometimes that includes old/garbage data that winds up getting interpreted as button messages.)